### PR TITLE
Wrong parameter type ("boot") fails compilation process

### DIFF
--- a/6.1-rc/amd-pstate-epp-patches-v2-sep/0001-ACPI-CPPC-Add-AMD-pstate-energy-performance-preferen.patch
+++ b/6.1-rc/amd-pstate-epp-patches-v2-sep/0001-ACPI-CPPC-Add-AMD-pstate-energy-performance-preferen.patch
@@ -197,7 +197,7 @@ index c56144440..a93393b05 100644
  {
  	return -ENOTSUPP;
  }
-+static inline int cppc_set_epp_perf(int cpu, struct cppc_perf_ctrls *perf_ctrls, boot enable)
++static inline int cppc_set_epp_perf(int cpu, struct cppc_perf_ctrls *perf_ctrls, bool enable)
 +{
 +	return -ENOTSUPP;
 +}


### PR DESCRIPTION
As denoted by GCC, which suggested the parameter type of "bool" instead of the current type "boot" which seemingly is a misspelling.